### PR TITLE
Fixed missing colnames issue for seurat5

### DIFF
--- a/R/makeH5fromSeurat.R
+++ b/R/makeH5fromSeurat.R
@@ -41,13 +41,13 @@ makeH5fromSeurat <- function(obj, sc1meta, filename,
     # Seurat v5
     for(i in 1:nChunk){
       sc1gexpr.grp.data[((i-1)*chk+1):(i*chk), ] <- as.matrix(
-        obj@assays[[gex.assay]]@layers[[gex.slot]][
+        obj[[gex.assay]][gex.slot][
           ((i-1)*chk+1):(i*chk), sc1meta$cellID])
     }
       sc1gexpr.grp.data[(i*chk+1):gex.matdim[1], ] <- as.matrix(
-        obj@assays[[gex.assay]]@layers[[gex.slot]][
+        obj[[gex.assay]][gex.slot][
           (i*chk+1):gex.matdim[1], sc1meta$cellID])
-      gex.rownm = rownames(obj@assays[[gex.assay]]@layers[[gex.slot]])
+      gex.rownm = rownames(obj[[gex.assay]][gex.slot])
       
   } else {
     for(i in 1:nChunk){


### PR DESCRIPTION
## Fixes #3

This PR resolves an error that occurs when accessing expression data using:

`obj@assays[[gex.assay]]@layers[[gex.slot]]`

This matrix does not contain `dimnames`, which causes the following error when subsetting by cellID:

```r
Error in .subscript.2ary(x, i, j, drop = TRUE): subscript out of bounds
Traceback:

1. makeShinyFiles(so, scConf, shiny.dir = "ShinyCell2/)", assay.slot = "data", 
 .     dimred.to.use = "umap", bigWigGroup = "cell_ID")
2. makeShinyFilesGEX(obj, scConf, assay, assay.slot, dimred.to.use, 
 .     shiny.prefix, shiny.dir, default.gene1, default.gene2, default.multigene, 
 .     default.dimred, chunkSize)
3. makeH5fromSeurat(obj, sc1meta, filename = filename, gex.assay = iAssay, 
 .     gex.slot = gex.slot[1], chunkSize = chunkSize)
4. as.matrix(obj@assays[[gex.assay]]@layers[[gex.slot]][((i - 1) * 
 .     chk + 1):(i * chk), sc1meta$cellID])
5. obj@assays[[gex.assay]]@layers[[gex.slot]][((i - 1) * chk + 1):(i * 
 .     chk), sc1meta$cellID]
6. obj@assays[[gex.assay]]@layers[[gex.slot]][((i - 1) * chk + 1):(i * 
 .     chk), sc1meta$cellID]
7. .subscript.2ary(x, i, j, drop = TRUE)
8. stop("subscript out of bounds")
```
To fix this, I replaced the access with:

`obj[[gex.assay]][gex.slot]`

This alternative returns a matrix that includes `dimnames`, allowing subsetting by cellID to work as expected.