### PR TITLE
Replace deprecated argument

### DIFF
--- a/R/writer0.R
+++ b/R/writer0.R
@@ -40,7 +40,7 @@ wrShFunc <- function() {
     '    text =             element_text(size = base_size, family = "Helvetica"), \n',
     '    panel.background = element_rect(fill = "white", colour = NA), \n',
     '    axis.line =   element_line(colour = "black"), \n',
-    '    axis.ticks =  element_line(colour = "black", size = base_size / 20), \n',
+    '    axis.ticks =  element_line(colour = "black", linewidth = base_size / 20), \n',
     '    axis.title =  element_text(face = "bold"), \n',
     '    axis.text =   element_text(size = base_size), \n',
     '    axis.text.x = element_text(angle = Xang, hjust = XjusH), \n',


### PR DESCRIPTION
Warning: The 'size' argument of 'element_line()' is deprecated as of ggplot2 3.4.0.
Please use the 'linewidth' argument instead.