### PR TITLE
Move ShinyCell2 link (and surrounding lines) outside of the navbarPage

### DIFF
--- a/R/writer2.R
+++ b/R/writer2.R
@@ -1161,12 +1161,13 @@ wrUIpost <- function(footnote) {
   }
   
   glue::glue(
+    '  ),   # End of navbarPage \n\n',
     '    br(), \n',
     '    p({f0}), \n',
     '    p(em("This webpage was made using "), a("ShinyCell2", \n',
     '       href = "https://github.com/the-ouyang-lab/ShinyCell2",target="_blank")), \n',
     '    br(),br(),br(),br(),br()  \n',
-    '  )))  \n\n\n'
+    '  ))  \n\n\n'
   )
 }
 


### PR DESCRIPTION
to avoid this warning message:
Warning: Navigation containers expect a collection of `bslib::nav_panel()`/`shiny::tabPanel()`s and/or `bslib::nav_menu()`/`shiny::navbarMenu()`s. Consider using `header` or `footer` if you wish to place content above (or below) every panel's contents.